### PR TITLE
Add time bonus on correct answer

### DIFF
--- a/script.js
+++ b/script.js
@@ -165,6 +165,8 @@ document.addEventListener('DOMContentLoaded', () => {
         const wasCorrect = (choice === correctAnswer);
         if (wasCorrect) {
           correctAnswers++;
+          timeLeft += 10;
+          document.getElementById('timer').textContent = formatTime(timeLeft);
         }
         endQuestion(wasCorrect);
       }


### PR DESCRIPTION
## Summary
- extend timer by 10s when a correct answer is eaten

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884b17858848326be3eeec284007c3f